### PR TITLE
Change defaults on assembly parameters

### DIFF
--- a/conf/params.config
+++ b/conf/params.config
@@ -13,12 +13,12 @@ params {
         ---------------------------
         */
         //abyss
-        abyss = true
+        abyss = false
         abyssKmerSize = 96
         abyssBloomSize = '2G'
 
         //BCALM2
-        bcalm = true
+        bcalm = false
         bcalmKmerSize = 31
 
         //GATB Minia Pipeline
@@ -31,11 +31,11 @@ params {
         idba = true
 
         //METAHIPMER2
-        metahipmer2 = true
+        metahipmer2 = false
         metahipmer2KmerSize = '21,33,55,77,99'
 
         //Minia
-        minia = true
+        minia = false
         miniaKmerSize = 31
 
         //MEGAHIT
@@ -57,7 +57,7 @@ params {
         unicycler = true
 
         //VelvetOptimiser
-        velvetoptimiser = true
+        velvetoptimiser = false
         velvetoptimiser_hashs = 19
         velvetoptimiser_hashe = 31
 


### PR DESCRIPTION
This PR removes the default execution of the following assemblers:

- ABySS, 
- BCALM2, 
- MetaHipmer2, 
- minia 
- VelvetOptimiser