### PR TITLE
Add script to pre-download all images before LMAS execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,34 @@ Java 8 (or higher) to be installed. More instructions are available [here](https
 
 You can clone this repository with `git clone git@github.com:cimendes/LMAS.git`, and all files will be in your local machine.
 
+##### Download all containers
+
+This is usually handled by Nextflow during its execution, but if for whatever reason you require the images to be downloaded before you run LMAS, the `pull_images.sh` script will do that for you!
+
+To download all images required to run LMAS simply run:
+
+```bash
+sh pull_images.sh
+```
+
+This script supports `shifter`, `singularity` and `docker`, recognizing the available software without needing user input.
+
 ## Running LMAS
 
 To run LMAS you can simply call it with:
+
 ```bash
-   LMAS <options>
-```   
+LMAS <options>
+```
+
 If no option or `--help` is provided, LMAS will display its help message. Otherwise, the `--fastq` and `--reference` options are mandatory. By default they are set to `'data/fastq/*_{1,2}.*'` and `'data/reference/*.fasta'` respectively.
 
 Alternatively you can call LMAS directly with Nextflow:
+
 ```bash
-   nextflow run main.nf <options>
+nextflow run main.nf <options>
 ```
+
 To use LMAS the following options are available:
 
 

--- a/pull_images.sh
+++ b/pull_images.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -x "$(command -v shifter)" ]; then
+  echo "Pulling images with shifter..." >&2
+  pull_command="shifterimg pull "
+
+elif [ -x "$(command -v singularity)" ]; then
+  echo "Pulling images with singularity..." >&2
+  pull_command="singularity pull docker://"
+
+elif [ -x "$(command -v docker)" ]; then
+  echo "Pulling images with docker..." >&2
+  pull_command="docker pull "
+
+else
+  echo "No container software found. Exiting..." >&2
+fi
+
+eval $pull_command"pcerqueira/bbtools:38.44"
+eval $pull_command"cimendes/abyss:2.3.1-1"
+eval $pull_command"cimendes/gatb-minia-pipeline:31.07.2020-1"
+eval $pull_command"cimendes/idba:1.1.3-1"
+eval $pull_command"cimendes/megahit-assembler:1.2.9-1"
+eval $pull_command"cimendes/mhm2:v2.0.0-65-gaad446d-generic"
+eval $pull_command"cimendes/spades:3.15.3-1"
+eval $pull_command"cimendes/minia:3.2.6-1"
+eval $pull_command"cimendes/skesa:2.5.0-1"
+eval $pull_command"cimendes/unicycler:0.4.9-1"
+eval $pull_command"cimendes/velvetoptimiser:2.2.6-1"
+eval $pull_command"cimendes/minimap2:2.22-1"


### PR DESCRIPTION
This PR adds instructions on how to pull all containers from the head node ahead of time to prepare for LMAS execution on a node not connected to the Internet.

Updates:
- Added pull_images.sh script
- Updated README with run instructions for the pull_images.sh script
