### PR TITLE
Up github action checkout version

### DIFF
--- a/.github/workflows/ci_nextflow.yml
+++ b/.github/workflows/ci_nextflow.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         nxf_ver: ['21.04.1', '']
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - name: Install Nextflow
         run: |
           export NXF_VER=${{ matrix.nxf_ver }}

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
          python-version: 3.8
       


### PR DESCRIPTION
This PR fixes the warnings in the GH actions regarding deprecated versions